### PR TITLE
Enforce https for newsletter signup form.

### DIFF
--- a/_includes/_html/newsletter.html
+++ b/_includes/_html/newsletter.html
@@ -1,4 +1,4 @@
-<form action="//epfl.us14.list-manage.com/subscribe/post?u=77300fa91ed5888d5c449c0b2&amp;id=cc4baeef24"
+<form action="https://epfl.us14.list-manage.com/subscribe/post?u=77300fa91ed5888d5c449c0b2&amp;id=cc4baeef24"
       method="post"
       id="mc-embedded-subscribe-form"
       name="mc-embedded-subscribe-form"


### PR DESCRIPTION
Now that polyprog.epfl.ch is hosted on GitHub, we can't use https (at
least not without Cloudflare or a similar proxy). However, we can make
sure that forms are still transmitted over https if their destination
supports it.